### PR TITLE
Changed most args to optional, updated to work with latest alttester

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ options:
 ```
 
 ### Example
-`python3 -m altins --release="2.1.0" --buildFile="Assets/Editor/Build/ProjectBuilderAndroid.cs" --buildMethod="Build" --target=="Android"`
+`python3 -m altins --release="2.1.0" --buildFile="Assets/Editor/Build/ProjectBuilderAndroid.cs" --buildMethod="Build" --target="Android"`
 
 For Evermerge, build file is either "Assets/Editor/Build/ProjectBuilderAndroid.cs" or "Assets/Editor/Build/ProjectBuilderIos.cs", and buildMethod should just be "Build"
 
@@ -49,7 +49,7 @@ pipeline {
         script {
           if (params.Test_Instrument) {
             sh 'pip3 install git+https://github.com/bigfishgames-external/AltTester-Instrumenter.git'
-            sh 'python3 -m altins --release="2.1.0" --buildFile="Assets/Editor/Build/ProjectBuilderAndroid.cs" --buildMethod="Build" --target=="Android"'
+            sh 'python3 -m altins --release="2.1.0" --buildFile="Assets/Editor/Build/ProjectBuilderAndroid.cs" --buildMethod="Build" --target="Android"'
           }
           sh '$UNITY_EXEC -buildTarget Android -executeMethod Build.BuildAndroid $UNITY_PARAMS'
         }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ options:
 ```
 
 ### Example
-`python3 -m altins --release="2.1.0" --buildFile="Assets/Editor/Build/ProjectBuilderAndroid.cs" --buildMethod="Build" --target=="Android"
+`python3 -m altins --release="2.1.0" --buildFile="Assets/Editor/Build/ProjectBuilderAndroid.cs" --buildMethod="Build" --target=="Android"`
+
+For Evermerge, build file is either "Assets/Editor/Build/ProjectBuilderAndroid.cs" or "Assets/Editor/Build/ProjectBuilderIos.cs", and buildMethod should just be "Build"
+
 
 ## Uninstall
 `pip3 uninstall AltTester-Instrumenter`

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pipeline {
         script {
           if (params.Test_Instrument) {
             sh 'pip3 install git+https://github.com/bigfishgames-external/AltTester-Instrumenter.git'
-            sh 'python3 -m altins --release="2.1.0" --assets="Assets" --settings="ProjectSettings/EditorBuildSettings.asset" --manifest="Packages/manifest.json" --buildFile="Assets/Editor/Build/ProjectBuilderAndroid.cs" --buildMethod="Build" --target=="Android" --inputSystem="old"'
+            sh 'python3 -m altins --release="2.1.0" --buildFile="Assets/Editor/Build/ProjectBuilderAndroid.cs" --buildMethod="Build" --target=="Android"'
           }
           sh '$UNITY_EXEC -buildTarget Android -executeMethod Build.BuildAndroid $UNITY_PARAMS'
         }

--- a/README.md
+++ b/README.md
@@ -12,18 +12,19 @@ options:
   -h, --help                    show this help message and exit
   --version                     show program's version number and exit
   --release     RELEASE         [required] The AltTester version to use.
-  --assets      ASSETS          [required] The Assets folder path.
-  --settings    SETTINGS        [required] The build settings file.
-  --manifest    MANIFEST        [required] The manifest file to modify.
   --buildFile   BUILDFILE       [required] The build file to modify.
   --buildMethod BUILDMETHOD     [required] The build method to modify.
-  --inputSystem INPUTSYSTEM     [required] Specify new or old.
-  --target      INPUTSYSTEM     [required] The build target (Android or iOS).
-  --newt        NEWTONSOFT      [required] Add newtonsoft to the manifest.
+  --target      TARGET          [required] The build target (Android or iOS).
+  --assets      ASSETS          [optional, default='Assets'] Specify if there is a different Assets folder
+  --settings    SETTINGS        [optional, default='ProjectSettings/EditorBuildSettings.asset'] Specify if there is a different EditorBuildSettings.asset file
+  --manifest    MANIFEST        [optional, default='Packages/manifest.json'] Specify if there is a different manifest.json file to modify.
+  --newt        NEWTONSOFT      [optional, default='True'] Add newtonsoft to the manifest.
+  --inputSystem INPUTSYSTEM     [optional, default='old'] Specify new or old.
+
 ```
 
 ### Example
-`python3 -m altins --release="2.0.2" --assets="Assets" --settings="ProjectSettings/EditorBuildSettings.asset" --manifest="Packages/manifest.json" --buildFile="Assets/Scripts/Editor/Build.cs" --buildMethod="BuildAndroid()" --inputSystem="old" --target="Android" --newt="True"`
+`python3 -m altins --release="2.1.0" --buildFile="Assets/Editor/Build/ProjectBuilderAndroid.cs" --buildMethod="Build" --target=="Android"
 
 ## Uninstall
 `pip3 uninstall AltTester-Instrumenter`
@@ -45,7 +46,7 @@ pipeline {
         script {
           if (params.Test_Instrument) {
             sh 'pip3 install git+https://github.com/bigfishgames-external/AltTester-Instrumenter.git'
-            sh 'python3 -m altins --release="2.0.2" --assets="Assets" --settings="ProjectSettings/EditorBuildSettings.asset" --manifest="Packages/manifest.json" --buildFile="Assets/Scripts/Editor/Build.cs" --buildMethod="BuildAndroid()" --target=="Android" --inputSystem="old" --newt="True"'
+            sh 'python3 -m altins --release="2.1.0" --assets="Assets" --settings="ProjectSettings/EditorBuildSettings.asset" --manifest="Packages/manifest.json" --buildFile="Assets/Editor/Build/ProjectBuilderAndroid.cs" --buildMethod="Build" --target=="Android" --inputSystem="old"'
           }
           sh '$UNITY_EXEC -buildTarget Android -executeMethod Build.BuildAndroid $UNITY_PARAMS'
         }

--- a/altins.py
+++ b/altins.py
@@ -124,7 +124,6 @@ def get_scenes_of_game(settings):
         lines = f.readlines()
         for line in lines:
             if "path" in line:
-                print("SCENE NAME: ", line)
                 scenes.append(line[line.rindex(" ")+1:].rstrip("\n"))
     return scenes
 
@@ -151,7 +150,6 @@ def modify_build_file_method(scenes, buildFile, buildMethod, target):
         var instrumentationSettings = new AltInstrumentationSettings();"""
     i = 0
     for scene in scenes:
-        print("adding scene: ", scene)
         buildMethodBody = buildMethodBody + f"""
             var scene{i} = "{scene}";
             AltBuilder.InsertAltInScene(scene{i}, instrumentationSettings);"""

--- a/altins.py
+++ b/altins.py
@@ -52,12 +52,6 @@ def modify_manifest(manifest, newt = "True"):
     inputsystem = "com.unity.inputsystem"
     editorcoroutines = {"com.unity.editorcoroutines": "1.0.0"}
 
-    # get the current working directory
-    current_working_directory = os.getcwd()
-
-    # print output to the console
-    print('current directory = ', current_working_directory)
-
     with open(manifest,'r+') as file:
         file_data = json.load(file)
         if (newt == "True") and ("com.unity.nuget.newtonsoft-json" not in file_data):
@@ -124,7 +118,6 @@ def get_scenes_of_game(settings):
         lines = f.readlines()
         for line in lines:
             if "path" in line:
-                print("SCENE NAME: ", line)
                 scenes.append(line[line.rindex(" ")+1:].rstrip("\n"))
     return scenes
 
@@ -151,7 +144,7 @@ def modify_build_file_method(scenes, buildFile, buildMethod, target):
         var instrumentationSettings = new AltInstrumentationSettings();"""
     i = 0
     for scene in scenes:
-        print("adding scene: ", scene)
+        print("Adding Alttester to scene: ", scene)
         buildMethodBody = buildMethodBody + f"""
             var scene{i} = "{scene}";
             AltBuilder.InsertAltInScene(scene{i}, instrumentationSettings);"""

--- a/altins.py
+++ b/altins.py
@@ -52,6 +52,12 @@ def modify_manifest(manifest, newt = "True"):
     inputsystem = "com.unity.inputsystem"
     editorcoroutines = {"com.unity.editorcoroutines": "1.0.0"}
 
+    # get the current working directory
+    current_working_directory = os.getcwd()
+
+    # print output to the console
+    print('current directory = ', current_working_directory)
+
     with open(manifest,'r+') as file:
         file_data = json.load(file)
         if (newt == "True") and ("com.unity.nuget.newtonsoft-json" not in file_data):
@@ -118,6 +124,7 @@ def get_scenes_of_game(settings):
         lines = f.readlines()
         for line in lines:
             if "path" in line:
+                print("SCENE NAME: ", line)
                 scenes.append(line[line.rindex(" ")+1:].rstrip("\n"))
     return scenes
 
@@ -144,7 +151,7 @@ def modify_build_file_method(scenes, buildFile, buildMethod, target):
         var instrumentationSettings = new AltInstrumentationSettings();"""
     i = 0
     for scene in scenes:
-        print("Adding Alttester to scene: ", scene)
+        print("adding scene: ", scene)
         buildMethodBody = buildMethodBody + f"""
             var scene{i} = "{scene}";
             AltBuilder.InsertAltInScene(scene{i}, instrumentationSettings);"""

--- a/altins.py
+++ b/altins.py
@@ -124,6 +124,7 @@ def get_scenes_of_game(settings):
         lines = f.readlines()
         for line in lines:
             if "path" in line:
+                print("SCENE NAME: ", line)
                 scenes.append(line[line.rindex(" ")+1:].rstrip("\n"))
     return scenes
 
@@ -150,6 +151,7 @@ def modify_build_file_method(scenes, buildFile, buildMethod, target):
         var instrumentationSettings = new AltInstrumentationSettings();"""
     i = 0
     for scene in scenes:
+        print("adding scene: ", scene)
         buildMethodBody = buildMethodBody + f"""
             var scene{i} = "{scene}";
             AltBuilder.InsertAltInScene(scene{i}, instrumentationSettings);"""

--- a/altins.py
+++ b/altins.py
@@ -284,7 +284,7 @@ if __name__ == "__main__":
     modify_asmdef(assets=args.assets)
     modify_build_file_usings(buildFile=args.buildFile)
     scene_array = get_scenes_of_game(settings=args.settings)
-    modify_build_file_method(first_scene, buildFile=args.buildFile, buildMethod=args.buildMethod, target=args.target)
+    modify_build_file_method(scene_array, buildFile=args.buildFile, buildMethod=args.buildMethod, target=args.target)
 
     if "old" in args.inputSystem:
         if os.path.exists(f"{args.assets}/AltTester/AltServer/Input.cs"):

--- a/altins.py
+++ b/altins.py
@@ -284,7 +284,7 @@ if __name__ == "__main__":
     modify_asmdef(assets=args.assets)
     modify_build_file_usings(buildFile=args.buildFile)
     scene_array = get_scenes_of_game(settings=args.settings)
-    modify_build_file_method(scene_array, buildFile=args.buildFile, buildMethod=args.buildMethod, target=args.target)
+    modify_build_file_method(first_scene, buildFile=args.buildFile, buildMethod=args.buildMethod, target=args.target)
 
     if "old" in args.inputSystem:
         if os.path.exists(f"{args.assets}/AltTester/AltServer/Input.cs"):

--- a/altins.py
+++ b/altins.py
@@ -51,6 +51,13 @@ def modify_manifest(manifest, newt = "True"):
     newtonsoft = {"com.unity.nuget.newtonsoft-json": "3.0.1"}
     inputsystem = "com.unity.inputsystem"
     editorcoroutines = {"com.unity.editorcoroutines": "1.0.0"}
+
+    # get the current working directory
+    current_working_directory = os.getcwd()
+
+    # print output to the console
+    print('current directory = ', current_working_directory)
+
     with open(manifest,'r+') as file:
         file_data = json.load(file)
         if (newt == "True") and ("com.unity.nuget.newtonsoft-json" not in file_data):
@@ -102,7 +109,7 @@ def modify_asmdef(assets):
                 file.truncate()
                 json.dump(file_data, file, indent = 3)
 
-def get_first_scene(settings):
+def get_scenes_of_game(settings):
     """
     Gets a list of scenes from the given "EditorBuildSettings.asset" file.
     Args:
@@ -112,13 +119,15 @@ def get_first_scene(settings):
     """
     #print("get_scenes_of_game(settings)") #DEBUGGING
     #print(f"  settings: {settings}") #DEBUGGING
+    scenes = []
     with open(settings, "r") as f:
         lines = f.readlines()
         for line in lines:
             if "path" in line:
-                return line[line.rindex(" ")+1:].rstrip("\n")
+                scenes.append(line[line.rindex(" ")+1:].rstrip("\n"))
+    return scenes
 
-def modify_build_file_method(scene, buildFile, buildMethod, target):
+def modify_build_file_method(scenes, buildFile, buildMethod, target):
     """
     Modifies the given method in the given ".cs" file to add AltTester objects to the given first scene in the app
     
@@ -138,8 +147,13 @@ def modify_build_file_method(scene, buildFile, buildMethod, target):
         if (buildTargetGroup == UnityEditor.BuildTargetGroup.Standalone) {{
             AltBuilder.CreateJsonFileForInputMappingOfAxis();
         }}
-        var instrumentationSettings = new AltInstrumentationSettings();
-        AltBuilder.InsertAltInScene("{scene}", instrumentationSettings);"""
+        var instrumentationSettings = new AltInstrumentationSettings();"""
+    i = 0
+    for scene in scenes:
+        buildMethodBody = buildMethodBody + f"""
+            var scene{i} = "{scene}";
+            AltBuilder.InsertAltInScene(scene{i}, instrumentationSettings);"""
+        i+=1
     with open(buildFile, 'r') as infile:
         data = infile.read()
     rowData = data.split("\n")
@@ -269,7 +283,7 @@ if __name__ == "__main__":
     modify_manifest(manifest=args.manifest, newt=args.newt)
     modify_asmdef(assets=args.assets)
     modify_build_file_usings(buildFile=args.buildFile)
-    first_scene = get_first_scene(args.settings)
+    scene_array = get_scenes_of_game(settings=args.settings)
     modify_build_file_method(first_scene, buildFile=args.buildFile, buildMethod=args.buildMethod, target=args.target)
 
     if "old" in args.inputSystem:


### PR DESCRIPTION
Most of the arguments were to put in the location of a certain file for the game on Unity, these files are typically stored in the same location for each project so made their inclusion optional and set default to where they should be.

Latest AltTester required different imports.

Some additional bugfixes