### PR TITLE
Update altins.py

### DIFF
--- a/altins.py
+++ b/altins.py
@@ -139,8 +139,8 @@ def modify_build_file_method(scene, buildFile, buildMethod, target, hostname, ho
             AltBuilder.CreateJsonFileForInputMappingOfAxis();
         }}
         var instrumentationSettings = new AltInstrumentationSettings();
-        instrumentationSettings.AltServerHost = hostname;
-        instrumentationSettings.AltServerPort = hostport;
+        instrumentationSettings.AltServerHost = {hostname};
+        instrumentationSettings.AltServerPort = {hostport};
         AltBuilder.InsertAltInScene("{scene}", instrumentationSettings);"""
     with open(buildFile, 'r') as infile:
         data = infile.read()

--- a/altins.py
+++ b/altins.py
@@ -119,7 +119,7 @@ def get_first_scene(settings):
                 return line[line.rindex(" ")+1:].rstrip("\n")
 
 def modify_build_file_method(scene, buildFile, buildMethod, target, hostname, hostport):
-    '''
+    """
     Modifies the given method in the given ".cs" file to add AltTester objects to the given first scene in the app
     
     Args:
@@ -127,7 +127,7 @@ def modify_build_file_method(scene, buildFile, buildMethod, target, hostname, ho
         `string` buildFile: The build file to modify.
         `string` buildMethod: The build method to modify.
         `string` target: The target to build ("Android" or "iOS").
-    '''
+    """
     #print("modify_build_file_method(scenes, buildFile, buildMethod)") #DEBUGGING
     #print(f"  scenes: {scenes}") #DEBUGGING
     #print(f"  buildFile: {buildFile}") #DEBUGGING

--- a/altins.py
+++ b/altins.py
@@ -245,6 +245,19 @@ def remove_new_input_system(assets):
     delete_using(f"{assets}/AltTester/AltServer/Input.cs", "UnityEngine.InputSystem.UI")
     delete_csharp_if(f"{assets}/AltTester/AltServer/AltMockUpPointerInputModule.cs", "InputSystemUIInputModule")
     delete_using(f"{assets}/AltTester/AltServer/AltMockUpPointerInputModule.cs", "UnityEngine.InputSystem.UI")
+
+def remove_location_reference():
+    with open("/Assets/AltTester/Runtime/Input.cs", 'r') as infile:
+        data = infile.read()
+    
+    rowData = data.split("\n")
+    outData = []
+    for i in range(len(rowData)):
+        if "LocationService" not in rowData[i]:
+            outData.append(rowData[i])
+    with open("/Assets/AltTester/Runtime/Input.cs", 'w') as outfile:
+        outfile.write('\n'.join(outData))
+    
 # Main entry point.
 if __name__ == "__main__":
     v = "unknown"
@@ -272,6 +285,8 @@ if __name__ == "__main__":
     modify_build_file_usings(buildFile=args.buildFile)
     first_scene = get_first_scene(args.settings)
     modify_build_file_method(first_scene, buildFile=args.buildFile, buildMethod=args.buildMethod, target=args.target, hostname=args.hostname, hostport=args.hostport)
+    if "iOS" in args.target:
+        remove_location_reference()
 
     if "old" in args.inputSystem:
         if os.path.exists(f"{args.assets}/AltTester/AltServer/Input.cs"):

--- a/altins.py
+++ b/altins.py
@@ -159,9 +159,6 @@ def modify_build_file_method(scene, buildFile, buildMethod, target, hostname, ho
         outData.insert(line_to_add_code, buildMethodBody)
     with open(buildFile, 'w') as outfile:
         outfile.write('\n'.join(outData))
-    print('PRINTING ENTIRE FILE FOR DEBUG')
-    with open(buildFile, 'r') as f:
-        print(f.read())
 def delete_line_and_preceding (file_path, value):
     """
     Removes the line of code that contains the given sting and the line preceeding it from the returned data.

--- a/altins.py
+++ b/altins.py
@@ -118,8 +118,8 @@ def get_first_scene(settings):
             if "path" in line:
                 return line[line.rindex(" ")+1:].rstrip("\n")
 
-def modify_build_file_method(scene, buildFile, buildMethod, target):
-    """
+def modify_build_file_method(scene, buildFile, buildMethod, target, hostname, hostport):
+    '''
     Modifies the given method in the given ".cs" file to add AltTester objects to the given first scene in the app
     
     Args:
@@ -127,7 +127,7 @@ def modify_build_file_method(scene, buildFile, buildMethod, target):
         `string` buildFile: The build file to modify.
         `string` buildMethod: The build method to modify.
         `string` target: The target to build ("Android" or "iOS").
-    """
+    '''
     #print("modify_build_file_method(scenes, buildFile, buildMethod)") #DEBUGGING
     #print(f"  scenes: {scenes}") #DEBUGGING
     #print(f"  buildFile: {buildFile}") #DEBUGGING
@@ -139,6 +139,8 @@ def modify_build_file_method(scene, buildFile, buildMethod, target):
             AltBuilder.CreateJsonFileForInputMappingOfAxis();
         }}
         var instrumentationSettings = new AltInstrumentationSettings();
+        instrumentationSettings.AltServerHost = hostname;
+        instrumentationSettings.AltServerPort = hostport;
         AltBuilder.InsertAltInScene("{scene}", instrumentationSettings);"""
     with open(buildFile, 'r') as infile:
         data = infile.read()
@@ -258,6 +260,8 @@ if __name__ == "__main__":
     parser.add_argument("--buildMethod", required=True, help="[required] The build method to modify.")
     parser.add_argument("--target", required=True, help="[required] The build target (Android or iOS).")    
     parser.add_argument("--assets", required=False, default="Assets", help="[optional, default='Assets'] The Assets folder path.")
+    parser.add_argument("--hostname", required=False, default="127.0.0.1", help="[optional, default='127.0.0.1'] The default hostname for the alttester server")
+    parser.add_argument("--hostport", required=False, default="13000", help="[optional, default='13000'] The default host port for the alttester server")
     parser.add_argument("--settings", required=False, default="ProjectSettings/EditorBuildSettings.asset", help="[optional, default='ProjectSettings/EditorBuildSettings.asset'] The build settings file.")
     parser.add_argument("--manifest", required=False, default="Packages/manifest.json", help="[optional, default='Packages/manifest.json'] The manifest file to modify.")
     parser.add_argument("--newt", required=False, default="True", help="[optional, default='True'] Include newtonsoft in the main manifest.json.")
@@ -270,7 +274,7 @@ if __name__ == "__main__":
     modify_asmdef(assets=args.assets)
     modify_build_file_usings(buildFile=args.buildFile)
     first_scene = get_first_scene(args.settings)
-    modify_build_file_method(first_scene, buildFile=args.buildFile, buildMethod=args.buildMethod, target=args.target)
+    modify_build_file_method(first_scene, buildFile=args.buildFile, buildMethod=args.buildMethod, target=args.target, hostname=args.hostname, hostport=args.hostport)
 
     if "old" in args.inputSystem:
         if os.path.exists(f"{args.assets}/AltTester/AltServer/Input.cs"):

--- a/altins.py
+++ b/altins.py
@@ -276,8 +276,8 @@ if __name__ == "__main__":
     modify_manifest(manifest=args.manifest, newt=args.newt)
     modify_asmdef(assets=args.assets)
     modify_build_file_usings(buildFile=args.buildFile)
-    first_scene = get_first_scene(args.settings)
-    modify_build_file_method(first_scene, buildFile=args.buildFile, buildMethod=args.buildMethod, target=args.target, hostname=args.hostname, hostport=args.hostport)
+    #first_scene = get_first_scene(args.settings)
+    #modify_build_file_method(first_scene, buildFile=args.buildFile, buildMethod=args.buildMethod, target=args.target, hostname=args.hostname, hostport=args.hostport)
 
     if "old" in args.inputSystem:
         if os.path.exists(f"{args.assets}/AltTester/AltServer/Input.cs"):

--- a/altins.py
+++ b/altins.py
@@ -139,7 +139,7 @@ def modify_build_file_method(scene, buildFile, buildMethod, target, hostname, ho
             AltBuilder.CreateJsonFileForInputMappingOfAxis();
         }}
         var instrumentationSettings = new AltInstrumentationSettings();
-        instrumentationSettings.AltServerHost = {hostname};
+        instrumentationSettings.AltServerHost = '{hostname}';
         instrumentationSettings.AltServerPort = {hostport};
         AltBuilder.InsertAltInScene("{scene}", instrumentationSettings);"""
     with open(buildFile, 'r') as infile:

--- a/altins.py
+++ b/altins.py
@@ -246,8 +246,8 @@ def remove_new_input_system(assets):
     delete_csharp_if(f"{assets}/AltTester/AltServer/AltMockUpPointerInputModule.cs", "InputSystemUIInputModule")
     delete_using(f"{assets}/AltTester/AltServer/AltMockUpPointerInputModule.cs", "UnityEngine.InputSystem.UI")
 
-def remove_location_reference():
-    with open("/Assets/AltTester/Runtime/Input.cs", 'r') as infile:
+def remove_location_reference(assets):
+    with open(f"{assets}/AltTester/Runtime/Input.cs", 'r') as infile:
         data = infile.read()
     
     rowData = data.split("\n")
@@ -255,7 +255,7 @@ def remove_location_reference():
     for i in range(len(rowData)):
         if "LocationService" not in rowData[i]:
             outData.append(rowData[i])
-    with open("/Assets/AltTester/Runtime/Input.cs", 'w') as outfile:
+    with open(f"{assets}/AltTester/Runtime/Input.cs", 'w') as outfile:
         outfile.write('\n'.join(outData))
     
 # Main entry point.
@@ -286,7 +286,7 @@ if __name__ == "__main__":
     first_scene = get_first_scene(args.settings)
     modify_build_file_method(first_scene, buildFile=args.buildFile, buildMethod=args.buildMethod, target=args.target, hostname=args.hostname, hostport=args.hostport)
     if "iOS" in args.target:
-        remove_location_reference()
+        remove_location_reference(args.assets)
 
     if "old" in args.inputSystem:
         if os.path.exists(f"{args.assets}/AltTester/AltServer/Input.cs"):

--- a/altins.py
+++ b/altins.py
@@ -136,7 +136,7 @@ def modify_build_file_method(scene, buildFile, buildMethod, target, hostname, ho
         var buildTargetGroup = BuildTargetGroup.{target};
         AltBuilder.AddAltTesterInScriptingDefineSymbolsGroup(buildTargetGroup);
         var instrumentationSettings = new AltInstrumentationSettings();
-        instrumentationSettings.AltServerHost = '{hostname}';
+        instrumentationSettings.AltServerHost = "{hostname}";
         instrumentationSettings.AltServerPort = {hostport};
         AltBuilder.InsertAltInScene("{scene}", instrumentationSettings);"""
     with open(buildFile, 'r') as infile:

--- a/altins.py
+++ b/altins.py
@@ -162,6 +162,9 @@ def modify_build_file_method(scene, buildFile, buildMethod, target, hostname, ho
         outData.insert(line_to_add_code, buildMethodBody)
     with open(buildFile, 'w') as outfile:
         outfile.write('\n'.join(outData))
+    print('PRINTING ENTIRE FILE FOR DEBUG')
+    with open(buildFile, 'r') as f:
+        print(f.read())
 def delete_line_and_preceding (file_path, value):
     """
     Removes the line of code that contains the given sting and the line preceeding it from the returned data.

--- a/altins.py
+++ b/altins.py
@@ -135,9 +135,6 @@ def modify_build_file_method(scene, buildFile, buildMethod, target, hostname, ho
     buildMethodBody = f"""\
         var buildTargetGroup = BuildTargetGroup.{target};
         AltBuilder.AddAltTesterInScriptingDefineSymbolsGroup(buildTargetGroup);
-        if (buildTargetGroup == UnityEditor.BuildTargetGroup.Standalone) {{
-            AltBuilder.CreateJsonFileForInputMappingOfAxis();
-        }}
         var instrumentationSettings = new AltInstrumentationSettings();
         instrumentationSettings.AltServerHost = '{hostname}';
         instrumentationSettings.AltServerPort = {hostport};
@@ -276,8 +273,8 @@ if __name__ == "__main__":
     modify_manifest(manifest=args.manifest, newt=args.newt)
     modify_asmdef(assets=args.assets)
     modify_build_file_usings(buildFile=args.buildFile)
-    #first_scene = get_first_scene(args.settings)
-    #modify_build_file_method(first_scene, buildFile=args.buildFile, buildMethod=args.buildMethod, target=args.target, hostname=args.hostname, hostport=args.hostport)
+    first_scene = get_first_scene(args.settings)
+    modify_build_file_method(first_scene, buildFile=args.buildFile, buildMethod=args.buildMethod, target=args.target, hostname=args.hostname, hostport=args.hostport)
 
     if "old" in args.inputSystem:
         if os.path.exists(f"{args.assets}/AltTester/AltServer/Input.cs"):


### PR DESCRIPTION
Adds ability to declare a custom hostname/port for the alttester instrumentation - also automatically deletes reference to the LocationService class on iOS builds which will break Unity unless it is defined in playersettings.